### PR TITLE
Support for Bukkit 1.20 and fix for give message

### DIFF
--- a/src/main/java/com/greatmancode/craftconomy3/commands/money/GiveCommand.java
+++ b/src/main/java/com/greatmancode/craftconomy3/commands/money/GiveCommand.java
@@ -58,7 +58,7 @@ public class GiveCommand extends AbstractCommand {
                     if (reciever != null) {
                         Common.getInstance().getServerCaller().getPlayerCaller().sendMessage(reciever.getUuid(), Common
                                 .getInstance().getLanguageManager().parse("money_give_received", Common.getInstance().format
-                                        (worldName, currency, amount), sender.getName()), this.getName());
+                                        (worldName, currency, amount), sender.getName()));
                     }
                 }
             } else {

--- a/src/main/java/com/greatmancode/craftconomy3/tools/caller/bukkit/BukkitPlayerCaller.java
+++ b/src/main/java/com/greatmancode/craftconomy3/tools/caller/bukkit/BukkitPlayerCaller.java
@@ -40,6 +40,8 @@ public class BukkitPlayerCaller extends PlayerCaller {
 
 
     private Player getBukkitPlayer(UUID uuid) {
+        if (uuid == null)
+            return null;
         return ((BukkitLoader) getCaller().getLoader()).getServer().getPlayer(uuid);
 
     }
@@ -139,7 +141,7 @@ public class BukkitPlayerCaller extends PlayerCaller {
 
     @Override
     public String getPlayerWorld(UUID uuid) {
-        Player p = ((BukkitLoader) getCaller().getLoader()).getServer().getPlayer(uuid);
+        Player p = getBukkitPlayer(uuid);
         return (p != null) ? p.getWorld().getName() : "";
     }
 
@@ -151,7 +153,7 @@ public class BukkitPlayerCaller extends PlayerCaller {
 
     @Override
     public boolean isOnline(UUID uuid) {
-        return ((BukkitLoader) getCaller().getLoader()).getServer().getPlayer(uuid) != null;
+        return getBukkitPlayer(uuid) != null;
     }
 
     @Override
@@ -209,7 +211,7 @@ public class BukkitPlayerCaller extends PlayerCaller {
 
     @Override
     public com.greatmancode.craftconomy3.tools.entities.Player getPlayer(UUID uuid) {
-        Player player = ((BukkitLoader) getCaller().getLoader()).getServer().getPlayer(uuid);
+        Player player = getBukkitPlayer(uuid);
         if (player == null) return null;
         CommandSender sender = new PlayerCommandSender<>(player.getDisplayName(), player.getUniqueId(), player);
         return new com.greatmancode.craftconomy3.tools.entities.Player(player.getName(),
@@ -231,7 +233,7 @@ public class BukkitPlayerCaller extends PlayerCaller {
 
     @Override
     public com.greatmancode.craftconomy3.tools.entities.Player getOnlinePlayer(UUID uuid) {
-        Player player = ((BukkitLoader) getCaller().getLoader()).getServer().getPlayer(uuid);
+        Player player = getBukkitPlayer(uuid);
         if (player == null) return null;
         if (player.isOnline()) {
             CommandSender sender = new PlayerCommandSender<>(player.getDisplayName(), player.getUniqueId(), player);


### PR DESCRIPTION
Hello,

Here is a contribution to fix 2 issues :
- Fix #111 - The message were not send when `commandName` is null but `commandName` is always filled with "give"
- Fix #196 - With Bukkit MC 1.20 call to `CraftServer.getPlayer` with null uuid generate an exception, so all console command generate exception. I added a check for state of uuid.