### PR TITLE
Add Spigot versions 1.17, 1.18, 1.19, 1.20 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         java-version: [ '11', '17' ]
-        spigot-version: [ '1.8.8', '1.9.4', '1.10.2', '1.11.2', '1.12.2', '1.13.2', '1.14.4', '1.15.2', '1.16.5' ]
+        spigot-version: [ '1.8.8', '1.9.4', '1.10.2', '1.11.2', '1.12.2', '1.13.2', '1.14.4', '1.15.2', '1.16.5', '1.17.1', '1.18.2', '1.19.4', '1.20.1' ]
 
     name: Tests on Java ${{ matrix.java-version }} & Spigot ${{ matrix.spigot-version }}
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,10 +84,57 @@
 
     <profiles>
         <profile>
-            <id>Spigot-1.16.5</id>
+            <id>Spigot-1.20.1</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.spigotmc</groupId>
+                    <artifactId>spigot-api</artifactId>
+                    <version>1.20.1-R0.1-SNAPSHOT</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>Spigot-1.19.4</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.spigotmc</groupId>
+                    <artifactId>spigot-api</artifactId>
+                    <version>1.19.4-R0.1-SNAPSHOT</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>Spigot-1.18.2</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.spigotmc</groupId>
+                    <artifactId>spigot-api</artifactId>
+                    <version>1.18.2-R0.1-SNAPSHOT</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>Spigot-1.17.1</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.spigotmc</groupId>
+                    <artifactId>spigot-api</artifactId>
+                    <version>1.17.1-R0.1-SNAPSHOT</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>Spigot-1.16.5</id>
             <dependencies>
                 <dependency>
                     <groupId>org.spigotmc</groupId>


### PR DESCRIPTION
Add maven profiles for Spigot versions:
- 1.17.1
- 1.18.2
- 1.19.4
- 1.20.1

and add these to GitHub actions (test.yml) for CI