### PR TITLE
Fix exception in Bukkit 1.20 on command "/money give" from console

### DIFF
--- a/src/main/java/com/greatmancode/craftconomy3/tools/caller/bukkit/BukkitPlayerCaller.java
+++ b/src/main/java/com/greatmancode/craftconomy3/tools/caller/bukkit/BukkitPlayerCaller.java
@@ -40,6 +40,9 @@ public class BukkitPlayerCaller extends PlayerCaller {
 
 
     private Player getBukkitPlayer(UUID uuid) {
+        if (uuid == null) {
+            return null;
+        }
         return ((BukkitLoader) getCaller().getLoader()).getServer().getPlayer(uuid);
 
     }
@@ -139,7 +142,7 @@ public class BukkitPlayerCaller extends PlayerCaller {
 
     @Override
     public String getPlayerWorld(UUID uuid) {
-        Player p = ((BukkitLoader) getCaller().getLoader()).getServer().getPlayer(uuid);
+        Player p = this.getBukkitPlayer(uuid);
         return (p != null) ? p.getWorld().getName() : "";
     }
 
@@ -151,7 +154,7 @@ public class BukkitPlayerCaller extends PlayerCaller {
 
     @Override
     public boolean isOnline(UUID uuid) {
-        return ((BukkitLoader) getCaller().getLoader()).getServer().getPlayer(uuid) != null;
+        return this.getBukkitPlayer(uuid) != null;
     }
 
     @Override
@@ -209,7 +212,7 @@ public class BukkitPlayerCaller extends PlayerCaller {
 
     @Override
     public com.greatmancode.craftconomy3.tools.entities.Player getPlayer(UUID uuid) {
-        Player player = ((BukkitLoader) getCaller().getLoader()).getServer().getPlayer(uuid);
+        Player player = this.getBukkitPlayer(uuid);
         if (player == null) return null;
         CommandSender sender = new PlayerCommandSender<>(player.getDisplayName(), player.getUniqueId(), player);
         return new com.greatmancode.craftconomy3.tools.entities.Player(player.getName(),
@@ -231,7 +234,7 @@ public class BukkitPlayerCaller extends PlayerCaller {
 
     @Override
     public com.greatmancode.craftconomy3.tools.entities.Player getOnlinePlayer(UUID uuid) {
-        Player player = ((BukkitLoader) getCaller().getLoader()).getServer().getPlayer(uuid);
+        Player player = this.getBukkitPlayer(uuid);
         if (player == null) return null;
         if (player.isOnline()) {
             CommandSender sender = new PlayerCommandSender<>(player.getDisplayName(), player.getUniqueId(), player);


### PR DESCRIPTION
Fix exception while trying to get player for console command (fix #196)
With Bukkit MC 1.20 call to CraftServer.getPlayer with null uuid
generate the following exception :
 java.lang.IllegalArgumentException: UUID id cannot be null

This fixes #196 

Originally by EpiCanard #197 